### PR TITLE
Add setup script for virtual environment

### DIFF
--- a/setup_venv.sh
+++ b/setup_venv.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+
+echo "🔍 Checking Python version..."
+python3 --version
+
+PY_VER=$(python3 -c "import sys; print(sys.version_info[:2] >= (3,12))")
+if [ "$PY_VER" != "True" ]; then
+  echo "❌ Required: Python 3.12 or higher. Installing..."
+  brew install python@3.12
+  echo 'export PATH="/opt/homebrew/opt/python@3.12/bin:$PATH"' >> ~/.zshrc
+  source ~/.zshrc
+fi
+
+echo "✅ Using Python: $(python3 --version)"
+
+# --- Create and activate virtual environment automatically ---
+if [ ! -d "venv" ]; then
+  echo "🐍 Creating virtual environment..."
+  python3 -m venv venv
+fi
+
+echo "🔗 Activating virtual environment..."
+source venv/bin/activate
+
+echo "📦 Upgrading pip inside virtualenv..."
+pip install --upgrade pip setuptools wheel
+
+echo "📦 Upgrading pip..."
+python3 -m ensurepip --upgrade
+python3 -m pip install --upgrade pip setuptools wheel
+
+echo "🧱 Creating virtual environment..."
+python3 -m venv venv
+source venv/bin/activate
+
+echo "📦 Installing build system (hatchling)..."
+pip install hatchling
+
+echo "📦 Installing dependencies from pyproject.toml..."
+
+pip install docker>=6 rich>=13
+
+# pip install black>=23 isort>=5 pytest>=7
+
+echo "📦 Installing kaprese package..."
+pip install .
+
+echo "🎉 kaprese installation complete!"
+echo "✅ To activate the virtual environment, run: source venv/bin/activate"
+echo "Run with: kaprese --help"


### PR DESCRIPTION
Enhance CLI documentation and improve setup script
## Summary
This PR improves the Kaprese setup/installation script (`setup.sh`) for macOS users to ensure a smoother onboarding experience.

### Changes
- Check for Python 3.12 or higher; automatically install via Homebrew if missing
- Create and activate a virtual environment (`venv`) automatically
- Upgrade `pip`, `setuptools`, and `wheel` inside the virtual environment
- Install required dependencies: `docker>=6` and `rich>=13`
- Install the Kaprese package itself (`pip install .`)
- Provide clear messages and instructions for users

### Usage
```bash
# Run the setup script
./setup.sh

# Activate virtual environment manually if needed
source venv/bin/activate

# Verify Kaprese installation
kaprese --help