### PR TITLE
Update type annotations in design.py for Python 3.12+ compliance

### DIFF
--- a/kaprese/utils/design.py
+++ b/kaprese/utils/design.py
@@ -1,8 +1,8 @@
-from typing import Any, Dict
+from typing import Any
 
 
 class Singleton(type):
-    __instances: Dict[type, Any] = {}
+    __instances: dict[type, Any] = {}
 
     def __call__(cls, *args: Any, **kwargs: Any) -> Any:
         if cls not in cls.__instances:


### PR DESCRIPTION
Modernizes type annotations in the `design.py` file to align with Python 3.12+ standards (PEP 585) by replacing `Dict` with the built-in `dict` type and removing unnecessary imports.

Fixes #106